### PR TITLE
check 'wrap != nullptr'  before dereferencing

### DIFF
--- a/src/udp_wrap.cc
+++ b/src/udp_wrap.cc
@@ -367,13 +367,17 @@ void UDPWrap::Disconnect(const FunctionCallbackInfo<Value>& args) {
 #define X(name, fn)                                                            \
   void UDPWrap::name(const FunctionCallbackInfo<Value>& args) {                \
     UDPWrap* wrap = Unwrap<UDPWrap>(args.Holder());                            \
+    if (wrap == nullptr) {                                                     \
+      args.GetReturnValue().Set(UV_EBADF);                                     \
+      return;                                                                  \
+    }                                                                          \
     Environment* env = wrap->env();                                            \
     CHECK_EQ(args.Length(), 1);                                                \
     int flag;                                                                  \
     if (!args[0]->Int32Value(env->context()).To(&flag)) {                      \
       return;                                                                  \
     }                                                                          \
-    int err = wrap == nullptr ? UV_EBADF : fn(&wrap->handle_, flag);           \
+    int err = fn(&wrap->handle_, flag);                                        \
     args.GetReturnValue().Set(err);                                            \
   }
 


### PR DESCRIPTION
### Time-of-check vs Time-of-use bug in [src/udp_wrap.cc:370](https://github.com/nodejs/node/blob/master/src/udp_wrap.cc#L370)

The pointer 'wrap' is checked against NULL on line 376, but it gets dereferenced at line 370.
Note comments for line 370 and 376.

```C
367   #define X(name, fn)                                                            \
368     void UDPWrap::name(const FunctionCallbackInfo<Value>& args) {                \
369       UDPWrap* wrap = Unwrap<UDPWrap>(args.Holder());                            \
370       Environment* env = wrap->env();                                            \
                            ^^^^^^^^^^^^^^ 'wrap' gets dereferenced here
371       CHECK_EQ(args.Length(), 1);                                                \
372       int flag;                                                                  \
373       if (!args[0]->Int32Value(env->context()).To(&flag)) {                      \
374         return;                                                                  \
375       }                                                                          \
376       int err = wrap == nullptr ? UV_EBADF : fn(&wrap->handle_, flag);           \
                   ^^^^^^^^^^^^^^^^^^ 'wrap' is checked against 'nullptr' here
377       args.GetReturnValue().Set(err);                                            \
378     }
```

Suggested solutions:

  1) Skip the null-check on line 376. If 'wrap' could be NULL, the code would have segfaulted.
  2) Add a null-check before the code at line 370


So the code becomes either:

1) with skipped null-check

```C
367   #define X(name, fn)                                                            \
368     void UDPWrap::name(const FunctionCallbackInfo<Value>& args) {                \
369       UDPWrap* wrap = Unwrap<UDPWrap>(args.Holder());                            \
370       Environment* env = wrap->env();                                            \
371       CHECK_EQ(args.Length(), 1);                                                \
372       int flag;                                                                  \
373       if (!args[0]->Int32Value(env->context()).To(&flag)) {                      \
374         return;                                                                  \
375       }                                                                          \
376       int err = fn(&wrap->handle_, flag);                                        \
377       args.GetReturnValue().Set(err);                                            \
378     }
```

... or 

2) with an added null-check, something like this

```C
367   #define X(name, fn)                                                            \
368     void UDPWrap::name(const FunctionCallbackInfo<Value>& args) {                \
369       UDPWrap* wrap = Unwrap<UDPWrap>(args.Holder());                            \
370       if (wrap == nullptr) {                                                     \
371         args.GetReturnValue().Set(err);                                          \
372         return;                                                                  \
373       }                                                                          \
374       Environment* env = wrap->env();                                            \
375       CHECK_EQ(args.Length(), 1);                                                \
376       int flag;                                                                  \
377       if (!args[0]->Int32Value(env->context()).To(&flag)) {                      \
378         return;                                                                  \
379       }                                                                          \
380       int err = fn(&wrap->handle_, flag);                                        \
381       args.GetReturnValue().Set(err);                                            \
382     }
```
