### PR TITLE
remove superfluous null-check

### DIFF
--- a/src/crypto/crypto_context.cc
+++ b/src/crypto/crypto_context.cc
@@ -1114,7 +1114,7 @@ int SecureContext::TicketKeyCallback(SSL* ssl,
     return -1;
   }
 
-  argv[2] = env != 0 ? v8::True(env->isolate()) : v8::False(env->isolate());
+  argv[2] = v8::True(env->isolate());
 
   Local<Value> ret;
   if (!node::MakeCallback(


### PR DESCRIPTION
Fix time-of-use/time-of-check 'bug' in [src/crypto/crypto_context.cc](https://github.com/nodejs/node/blob/master/src/crypto/crypto_context.cc#L1101)


The pointer 'env' is checked against NULL on line 1117, but it gets dereferenced at line 1101+1102.
Note comments for line 1101, 1102 and 1117.


```cpp
1089    int SecureContext::TicketKeyCallback(SSL* ssl,
1090                                         unsigned char* name,
1091                                         unsigned char* iv,
1092                                         EVP_CIPHER_CTX* ectx,
1093                                         HMAC_CTX* hctx,
1094                                         int enc) {
1095      static const int kTicketPartSize = 16;
1096    
1097      SecureContext* sc = static_cast<SecureContext*>(
1098          SSL_CTX_get_app_data(SSL_get_SSL_CTX(ssl)));
1099    
1100      Environment* env = sc->env();
1101      HandleScope handle_scope(env->isolate());
                                  ^^^^^^^^^^^^^^^^ 'env' gets dereferenced here
1102      Context::Scope context_scope(env->context());
                                      ^^^^^^^^^^^^^^^^ 'env' gets dereferenced here
1103    
1104      Local<Value> argv[3];
1105    
1106      if (!Buffer::Copy(
1107              env,
1108              reinterpret_cast<char*>(name),
1109              kTicketPartSize).ToLocal(&argv[0]) ||
1110          !Buffer::Copy(
1111              env,
1112              reinterpret_cast<char*>(iv),
1113              kTicketPartSize).ToLocal(&argv[1])) {
1114        return -1;
1115      }
1116    
1117      argv[2] = env != 0 ? v8::True(env->isolate()) : v8::False(env->isolate());
                                       ^^^^^^^^^^^^^^^^            ^^^^^^^^^^^^^^^^
                   ^^^^^^^^^^               'env' is dereferenced no matter if 'env != 0'
                        'env' is checked against NULL, but it was already dereferenced
1118                                        
```

Suggestion: Skip the null-check on line 1117. If 'env' could be NULL, the code would have segfaulted before reaching line 1117 anyway.